### PR TITLE
Обновить пути до podspec в README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ Acquiring SDK позволяет интегрировать [Интернет-Э
 Для подключения SDK мы рекомендуем использовать [Cocoa Pods][cocoapods]. Добавьте в файл Podfile зависимости
 ```c
 pod 'CardIO'
-pod 'ASDKCore', :podspec =>  "https://raw.githubusercontent.com/TinkoffCreditSystems/tinkoff-asdk-ios/master/ASDKCore.podspec"
-pod 'ASDKUI', :podspec =>  "https://raw.githubusercontent.com/TinkoffCreditSystems/tinkoff-asdk-ios/master/ASDKUI.podspec"
+pod 'ASDKCore', :podspec =>  "https://raw.githubusercontent.com/TinkoffCreditSystems/tinkoff-asdk-ios/1.3.11/ASDKCore.podspec"
+pod 'ASDKUI', :podspec =>  "https://raw.githubusercontent.com/TinkoffCreditSystems/tinkoff-asdk-ios/1.3.11/ASDKUI.podspec"
 ```
 
 Либо, если вы не используете [Cocoa Pods][cocoapods], можно добавить _**ASDKUI.xcodeproj**_ в ваш проект.


### PR DESCRIPTION
Пути в мастере ридми всё-таки должны указывать на последний текущий релиз. Иначе спустя следущий релиз ссылка из Podfile будет вести на другой podspec файл и надо будет обновлять Podfile.lock.