### PR TITLE
Fix sha256 encryption for iOS 13

### DIFF
--- a/ASDKCore/CryptoUtils/ASDKCryptoUtils.m
+++ b/ASDKCore/CryptoUtils/ASDKCryptoUtils.m
@@ -29,18 +29,15 @@
 
 + (NSString *)sha256:(NSString *)input
 {
-    NSData *inputData = [input dataUsingEncoding:NSASCIIStringEncoding];
-    uint8_t digest[CC_SHA256_DIGEST_LENGTH] = {0};
+    const char* str = [input UTF8String];
+    unsigned char result[CC_SHA256_DIGEST_LENGTH];
+    CC_SHA256(str, (CC_LONG)strlen(str), result);
     
-    CC_SHA256(inputData.bytes, (UInt32)inputData.length, digest);
-    
-    NSData *outData = [NSData dataWithBytes:digest length:CC_SHA256_DIGEST_LENGTH];
-    NSString *outString = [outData description];
-    
-    outString = [outString stringByReplacingOccurrencesOfString:@" " withString:@""];
-    outString = [outString stringByReplacingOccurrencesOfString:@"<" withString:@""];
-    outString = [outString stringByReplacingOccurrencesOfString:@">" withString:@""];
-    
+    NSMutableString *outString = [NSMutableString stringWithCapacity:CC_SHA256_DIGEST_LENGTH*2];
+    for(int i = 0; i<CC_SHA256_DIGEST_LENGTH; i++)
+    {
+        [outString appendFormat:@"%02x",result[i]];
+    }
     return outString;
 }
 


### PR DESCRIPTION
In iOS 13, the token looks like

> {length =32, bytes = 0x44154da7 32345001 53106883 ffc1071f ... a70871e5 aa8dbb41}

and when the request is executed, error 9999 is returned.